### PR TITLE
Validate Freshservice ticket identifiers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.2.4
     hooks:
       - id: build-docs
         language: python

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) Orro Group, 2023-2025
+   Copyright (c) Orro Group, 2023-2026
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
 Splunk SOAR App: Fresh Service
-Copyright (c) Orro Group, 2023-2025
+Copyright (c) Orro Group, 2023-2026

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Fresh Service
 
-Publisher: Orro Group \
-Connector Version: 1.1.1 \
-Product Vendor: freshworks \
-Product Name: freshservice \
+Publisher: Orro Group <br>
+Connector Version: 1.1.1 <br>
+Product Vendor: freshworks <br>
+Product Name: freshservice <br>
 Minimum Product Version: 6.3.0
 
 Fresh Service ITSM integration app
@@ -23,17 +23,17 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 
 ### Supported Actions
 
-[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration \
-[create ticket](#action-create-ticket) - Create a ticket (issue) \
-[get ticket](#action-get-ticket) - Get ticket (issue) information \
-[add note](#action-add-note) - Add a note to a ticket \
+[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration <br>
+[create ticket](#action-create-ticket) - Create a ticket (issue) <br>
+[get ticket](#action-get-ticket) - Get ticket (issue) information <br>
+[add note](#action-add-note) - Add a note to a ticket <br>
 [update ticket](#action-update-ticket) - Update ticket (issue)
 
 ## action: 'test connectivity'
 
 Validate the asset configuration for connectivity using supplied configuration
 
-Type: **test** \
+Type: **test** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -48,7 +48,7 @@ No Output
 
 Create a ticket (issue)
 
-Type: **generic** \
+Type: **generic** <br>
 Read only: **False**
 
 #### Action Parameters
@@ -81,7 +81,7 @@ summary.total_objects_successful | numeric | | |
 
 Get ticket (issue) information
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -104,7 +104,7 @@ summary.total_objects_successful | numeric | | |
 
 Add a note to a ticket
 
-Type: **generic** \
+Type: **generic** <br>
 Read only: **False**
 
 #### Action Parameters
@@ -131,7 +131,7 @@ summary.total_objects_successful | numeric | | |
 
 Update ticket (issue)
 
-Type: **generic** \
+Type: **generic** <br>
 Read only: **False**
 
 #### Action Parameters
@@ -172,7 +172,7 @@ ______________________________________________________________________
 
 Auto-generated Splunk SOAR Connector documentation.
 
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Splunk Inc.
+# Copyright (c) 2025-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/freshservice.json
+++ b/freshservice.json
@@ -7,10 +7,10 @@
     "logo": "logo_freshservice.svg",
     "logo_dark": "logo_freshservice_dark.svg",
     "product_name": "freshservice",
-    "python_version": "3",
+    "python_version": "3.9, 3.13",
     "product_version_regex": ".*",
     "publisher": "Orro Group",
-    "license": "Copyright (c) Orro Group, 2023-2025",
+    "license": "Copyright (c) Orro Group, 2023-2026",
     "app_version": "1.1.1",
     "utctime_updated": "2024-08-13T12:56:43.180093Z",
     "package_name": "phantom_freshservice",
@@ -530,5 +530,11 @@
             },
             "versions": "EQ(*)"
         }
-    ]
+    ],
+    "pip39_dependencies": {
+        "wheel": []
+    },
+    "pip313_dependencies": {
+        "wheel": []
+    }
 }

--- a/freshservice_connector.py
+++ b/freshservice_connector.py
@@ -1,6 +1,6 @@
 # File: freshservice_connector.py
 
-# Copyright (c) Orro Group, 2023-2025
+# Copyright (c) Orro Group, 2023-2026
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/freshservice_connector.py
+++ b/freshservice_connector.py
@@ -46,6 +46,18 @@ class FreshServiceConnector(BaseConnector):
         # modify this as you deem fit.
         self._base_url = None
 
+    @staticmethod
+    def _validate_ticket_id(action_result, value):
+        if isinstance(value, bool):
+            return RetVal(action_result.set_status(phantom.APP_ERROR, "Parameter 'ticket_id' must be a positive integer"), None)
+        try:
+            value = int(value)
+        except (TypeError, ValueError):
+            return RetVal(action_result.set_status(phantom.APP_ERROR, "Parameter 'ticket_id' must be a positive integer"), None)
+        if value <= 0:
+            return RetVal(action_result.set_status(phantom.APP_ERROR, "Parameter 'ticket_id' must be a positive integer"), None)
+        return RetVal(phantom.APP_SUCCESS, str(value))
+
     def _process_empty_response(self, response, action_result):
         if response.status_code == 200:
             return RetVal(phantom.APP_SUCCESS, {})
@@ -247,7 +259,9 @@ class FreshServiceConnector(BaseConnector):
         # Access action parameters passed in the 'param' dictionary
 
         # Set or get params
-        ticket_id = param["ticket_id"]
+        ret_val, ticket_id = self._validate_ticket_id(action_result, param["ticket_id"])
+        if phantom.is_fail(ret_val):
+            return action_result.get_status()
         # Get ticket endpoint, for this action.
         gt_endpoint = "/api/v2/tickets/"
         # Import this module for the HTTPBasicAuth shortcut in the request rather than b64 encoding and authorization header.
@@ -292,7 +306,9 @@ class FreshServiceConnector(BaseConnector):
         # Access action parameters passed in the 'param' dictionary
 
         # Required values can be accessed directly
-        ticket_id = param["ticket_id"]
+        ret_val, ticket_id = self._validate_ticket_id(action_result, param["ticket_id"])
+        if phantom.is_fail(ret_val):
+            return action_result.get_status()
         body = param["body"]
 
         # Optional values should use the .get() function
@@ -344,7 +360,9 @@ class FreshServiceConnector(BaseConnector):
         # Access action parameters passed in the 'param' dictionary
         # Set or get params
         # Required values can be accessed directly
-        ticket_id = param["ticket_id"]
+        ret_val, ticket_id = self._validate_ticket_id(action_result, param["ticket_id"])
+        if phantom.is_fail(ret_val):
+            return action_result.get_status()
         # Optional values should use the .get() function
         update_status = param.get("update_status", "")
         update_priority = param.get("update_priority", "")

--- a/freshservice_consts.py
+++ b/freshservice_consts.py
@@ -1,6 +1,6 @@
 # File: freshservice_connector.py
 
-# Copyright (c) Orro Group, 2023-2025
+# Copyright (c) Orro Group, 2023-2026
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,3 @@
 **Unreleased**
 
-* - Validate ticket identifiers before including them in Freshservice request paths.
+* Validate ticket identifiers before including them in Freshservice request paths.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+- Validate ticket identifiers before including them in Freshservice request paths.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,3 @@
 **Unreleased**
 
-- Validate ticket identifiers before including them in Freshservice request paths.
+* - Validate ticket identifiers before including them in Freshservice request paths.


### PR DESCRIPTION
## Summary\n\n- require Freshservice ticket identifiers to be positive integers before they enter request paths\n- apply the same validation to get ticket, add note, and update ticket\n- refresh the central hook and Python 3.9/3.13 packaging baseline\n\nTracks [PAPP-38185](https://splunk.atlassian.net/browse/PAPP-38185) and PSAAS-30914.\n\n## Quality gate\n\n- local pre-commit: passed\n- hosted pre-commit and compile: pending\n\nThis PR was created entirely with Codex (AI) assistance.

## Tracking

- PAPP: PAPP-38185
- PSAAS: PSAAS-30914
- Written by Codex.